### PR TITLE
Add README.rst to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst


### PR DESCRIPTION
Sadly, the version on PyPI doesn't install because `setup.py` reads from `README.rst`, which isn't included in the source distribution. This patch adds it in.

And don't worry, I forget to do this about 50% of the time on my Python packages too!