### PR TITLE
fix relative path expansion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,3 +42,9 @@ new console window. To suppress this window, use
 
 On Linux and macOS, graphical prompts are tried before ``sudo`` by default. To
 prevent graphical prompts, use ``elevate(graphical=False)``.
+
+On Linux and macOS, ``pkexec`` and some versions of ``sudo`` don't preserve the
+calling process' working directory. To fix this, ``elevate`` by default
+preserves the previous working directory. To disable this behaviour, if it is
+more insecure than useful, use ``elevate(restore_cwd=False)``. On Windows, the
+calling process' working directory is always preserved.

--- a/elevate/__init__.py
+++ b/elevate/__init__.py
@@ -1,7 +1,13 @@
 import sys
 
+import elevate.elevate_util as elevate_util
 
-def elevate(show_console=True, graphical=True):
+# this is run at import time so as to prevent argument parsers before
+#   the call to `elevate()` from breaking on our secret options
+elevate_util._ELEVATE_GOT_ARGS = elevate_util._process_elevate_opts()
+
+
+def elevate(show_console=True, graphical=True, restore_cwd=True):
     """
     Re-launch the current process with root/admin privileges
 
@@ -12,12 +18,14 @@ def elevate(show_console=True, graphical=True):
 
     :param show_console: (Windows only) if True, show a new console for the
         child process. Ignored on Linux / macOS.
-    :param graphical: (Linux / macOS only) if True, attempt to use graphical
+    :param graphical: (POSIX only) if True, attempt to use graphical
         programs (gksudo, etc). Ignored on Windows.
+    :param restore_cwd: (POSIX only) if False, the calling process' previous
+        working directory won't be restored after elevating.
+        Currently ignored on Windows.
     """
     if sys.platform.startswith("win"):
         from elevate.windows import elevate
     else:
         from elevate.posix import elevate
-    elevate(show_console, graphical)
-
+    elevate(show_console, graphical, restore_cwd)

--- a/elevate/elevate_util.py
+++ b/elevate/elevate_util.py
@@ -1,0 +1,77 @@
+import sys
+
+# two parts of the prefix of a special elevate command-line option
+_OPT_PREFIX = ("--_", "with-elevate-")
+# preserve the command-line arguments to elevate()
+_ELEVATE_GOT_ARGS = dict()
+
+
+def _process_elevate_opts():
+    """
+        Arguments:  none
+        Returns:    dict() mapping elevate command-line options to their values
+                    for clarity and disambiguation the `with-elevate-` prefixes
+                        are retained
+        Throws:     No
+        Effects:    Changes sys.argv, removing options specific to elevate
+
+        Simple option filter to remove and remember --_with-elevate-* options,
+            which would break argument parsers that appear before the
+            invocation of `elevate.elevate()`
+
+        These options allow elevate to give data to the elevated process it
+            will spawn.
+
+        This function reads and changes the entire argument list, and so
+            elevate's special options are not positional.
+
+        Calling this function again after the first time will have no effect.
+
+        Use _elevate_util._get_opt(opts, name) to get an option from this
+            dictionary.
+    """
+    opttest = lambda x, m=True: m == all(
+        ["=" in x, x.startswith( "".join(_OPT_PREFIX) )]
+    )
+
+    # copy sys.argv (compatibility)
+    old_argv = list(sys.argv)
+    # prevent user code from seeing elevate's options
+    sys.argv = list(filter(lambda x: opttest(x, False), old_argv))
+    return dict(map(
+        lambda y: y.split("_")[1].split("="), filter(opttest, old_argv)
+    ))
+
+
+def _get_opt(opts, name):
+    """
+        Arguments:  opts (a dictionary of options and values, like returned
+                        from _process_elevate_opts)
+                    name (the base name of the option to get, without its
+                        with-elevate prefix)
+        Returns:    The value of the option, which might be boolean, or False
+                        if the option wasn't specified
+        Throws:     No
+        Effects:    none
+
+        Safe/checked way to get an elevate option from a _process_elevate_opts
+            dictionary.
+    """
+    return opts.get(_OPT_PREFIX[1] + name, False)
+
+
+def _make_opt(name, param):
+    """
+        Arguments:  name (the base name of the option, without its
+                        'with-elevate-' prefix)
+                    param (the string value to specify as the parameter for the
+                        option)
+        Returns:    The string name of the command-line option, to be specified
+                        in the elevated process.
+        Throws:     No
+        Effects:    none
+
+        Format the special elevate option with the name `name` and the
+            parameter `param`, so that a process can be launched with it.
+    """
+    return "".join(_OPT_PREFIX + (name, "=", param))

--- a/example.py
+++ b/example.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import os
+import sys
+import argparse
+from elevate import elevate
+
+
+def is_root():
+    if sys.platform.startswith("win"):
+        from ctypes import windll
+        return bool(windll.shell32.IsUserAnAdmin())
+    else:
+        return os.getuid() == 0
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--sudo', action='store_true')
+parser.add_argument('file')
+# sudo'd process falls over here due to `--_` options?
+print(sys.argv)
+args = parser.parse_args()
+
+print("before: ", os.getcwd())
+print("before: ", is_root())
+
+if args.sudo:
+    elevate()
+file = args.file  # sys.argv[1]
+
+print("after:  ", os.getcwd())
+print("after:  ", is_root())
+print(file)
+print(os.getcwd())
+print(open(file, "r").readline())
+
+# should print: False True True and a line


### PR DESCRIPTION
closes #3, for Windows as well
closes #5  

before this patch
```
$ ./example.py 
before  False
['/usr/bin/python3', './example.py']
/usr/bin/python3: can't open file './example.py': [Errno 2] No such file or directory

# expected behaviour (with realpath) 
$ $(realpath example.py)
before  False
['/usr/bin/python3', '/home/cat/Sync/projects/git/elevate/example.py']
before  True
after  True
```

after this patch
```
$ example.py
before  False
['/usr/bin/python3', '/home/cat/Sync/projects/git/elevate/example.py']
before  True
after  True
```
