### PR TITLE
Add doas support

### DIFF
--- a/elevate/posix.py
+++ b/elevate/posix.py
@@ -45,6 +45,7 @@ def elevate(show_console=True, graphical=True):
             commands.append(["kdesudo"] + args)
 
     commands.append(["sudo"] + args)
+    commands.append(["doas"] + args)
 
     for args in commands:
         try:

--- a/elevate/posix.py
+++ b/elevate/posix.py
@@ -51,5 +51,5 @@ def elevate(show_console=True, graphical=True):
         try:
             os.execlp(args[0], *args)
         except OSError as e:
-            if e.errno != errno.ENOENT or args[0] == "sudo":
+            if e.errno != errno.ENOENT:
                 raise


### PR DESCRIPTION
Based on #18 by @wxllow.

I'm not aware of the intent behind `or args[0] == "sudo"` in the section reproduced below, so I may have broken something if that was important. All I know is that removing it prevented a `raise` that terminated the program before it could try `doas` instead of `sudo`.

```python
def elevate(show_console=True, graphical=True):
    ...
    for args in commands:
        try:
            os.execlp(args[0], *args)
        except OSError as e:
            if e.errno != errno.ENOENT or args[0] == "sudo":
                raise
```

Another solution I had (shown below) was to catch the FileNotFoundError that is raised when `sudo` is not found on PATH.

```python
def elevate(show_console=True, graphical=True):
    ...
    for args in commands:
        try:
            os.execlp(args[0], *args)
        except FileNotFoundError:
            raise               # sudo or doas not found 
        except OSError as e:
            if e.errno != errno.ENOENT or args[0] == "sudo":
                raise
```

This needs to be tested on a system which has only `sudo` (no `doas`) before being merged, so I've marked this PR as a draft.