### PR TITLE
Make Windows elevate paths UTF-8 compatible

### DIFF
--- a/elevate/windows.py
+++ b/elevate/windows.py
@@ -71,8 +71,8 @@ def elevate(show_console=True, graphical=True):
         fMask=SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE,
         hwnd=None,
         lpVerb=b'runas',
-        lpFile=sys.executable.encode('cp1252'),
-        lpParameters=subprocess.list2cmdline(sys.argv).encode('cp1252'),
+        lpFile=sys.executable.encode('utf-8'),
+        lpParameters=subprocess.list2cmdline(sys.argv).encode('utf-8'),
         nShow=int(show_console))
 
     if not ShellExecuteEx(ctypes.byref(params)):


### PR DESCRIPTION
While using elevate to run a script on a Turkish-localized computer with non-cp1252 characters (e.g. ğ ı ş) in the path, the script throws the following error (code is edited to obfuscate actual working environment and Turkish characters are an example):

```
(pulsar) PS C:\Users\####\yağdır> python src/####.py
Traceback (most recent call last):
  File "C:\Users\####\yağdır\src\####.py", line 49, in <module>
    elevate()
  File "C:\Users\####\yağdır\venv\Lib\site-packages\elevate\__init__.py", line 22, in elevate
    elevate(show_console, graphical)
  File "C:\Users\####\yağdır\venv\Lib\site-packages\elevate\windows.py", line 74, in elevate
    lpFile=sys.executable.encode('cp1252'),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.2544.0_x64__qbz5n2kfra8p0\Lib\encodings\cp1252.py", line 12, in encode
    return codecs.charmap_encode(input,errors,encoding_table)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u011f' in position 34: character maps to <undefined>
```

In playing with the code in windows.py changing lines 77 and 78 to 
```
        lpFile=sys.executable.encode('utf-8'),
        lpParameters=subprocess.list2cmdline(sys.argv).encode('utf-8'),
```
will allow the script to run in Windows Command Prompt (cmd.exe). However, it _will not_ run in PowerShell (tried in 5.1 and 7.4.3), because the output path looks like: `C:\Users\####\yaÄŸdÄ±r\venv\Scripts\python.exe`. Not exactly sure how to overcome that issue yet.